### PR TITLE
Update dea_check to work with updated version of acis_thermal_check

### DIFF
--- a/dea_check/__init__.py
+++ b/dea_check/__init__.py
@@ -1,5 +1,8 @@
 __version__ = "2.0.1"
 
+from .dea_check import \
+    calc_model
+
 def test(*args, **kwargs):
     '''
     Run py.test unit tests.

--- a/dea_check/__init__.py
+++ b/dea_check/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.0.1"
+__version__ = "2.1.0"
 
 from .dea_check import \
     calc_model

--- a/dea_check/dea_check.py
+++ b/dea_check/dea_check.py
@@ -23,23 +23,13 @@ import xija
 from acis_thermal_check import \
     ACISThermalCheck, \
     calc_off_nom_rolls, \
-    get_options, \
-    make_state_builder, \
-    get_acis_limits
+    get_options
 import os
 
 model_path = os.path.abspath(os.path.dirname(__file__))
 
-yellow_hi, red_hi = get_acis_limits("1deamzt")
 
 MSID = {"dea": '1DEAMZT'}
-# 10/02/14 - Changed YELLOW from 35.0 to 37.5
-#            Changed MARGIN from 2.5 to 2.0
-#            Modified corresponding VALIDATION_LIMITS:
-#                 (1, 2.5) -> (1, 2.0)
-#                 (99, 2.5) -> (99, 2.0)
-YELLOW = {"dea": yellow_hi}
-MARGIN = {"dea": 2.0}
 VALIDATION_LIMITS = {'1DEAMZT': [(1, 2.0), (50, 1.0), (99, 2.0)],
                      'PITCH': [(1, 3.0),(99, 3.0)],
                      'TSCPOS': [(1, 2.5), (99, 2.5)]
@@ -62,13 +52,12 @@ def calc_model(model_spec, states, start, stop, T_dea=None, T_dea_times=None):
 
 def main():
     args = get_options("dea", model_path)
-    state_builder = make_state_builder(args.state_builder, args)
-    dea_check = ACISThermalCheck("1deamzt", "dea", MSID, YELLOW,
-                                 MARGIN, VALIDATION_LIMITS,
-                                 HIST_LIMIT, calc_model)
+    dea_check = ACISThermalCheck("1deamzt", "dea", MSID, 
+                                 VALIDATION_LIMITS, HIST_LIMIT, 
+                                 calc_model, args)
 
     try:
-        dea_check.driver(args, state_builder)
+        dea_check.driver()
     except Exception as msg:
         if args.traceback:
             raise

--- a/dea_check/dea_check.py
+++ b/dea_check/dea_check.py
@@ -36,7 +36,8 @@ VALIDATION_LIMITS = {'1DEAMZT': [(1, 2.0), (50, 1.0), (99, 2.0)],
                      }
 HIST_LIMIT = [20.]
 
-def calc_model(model_spec, states, start, stop, T_dea=None, T_dea_times=None):
+def calc_model(model_spec, states, start, stop, T_dea=None, T_dea_times=None,
+               dh_heater=None, dh_heater_times=None):
     model = xija.ThermalModel('dea', start=start, stop=stop,
                               model_spec=model_spec)
     times = np.array([states['tstart'], states['tstop']])

--- a/dea_check/dea_check.py
+++ b/dea_check/dea_check.py
@@ -28,8 +28,6 @@ import os
 
 model_path = os.path.abspath(os.path.dirname(__file__))
 
-
-MSID = {"dea": '1DEAMZT'}
 VALIDATION_LIMITS = {'1DEAMZT': [(1, 2.0), (50, 1.0), (99, 2.0)],
                      'PITCH': [(1, 3.0),(99, 3.0)],
                      'TSCPOS': [(1, 2.5), (99, 2.5)]
@@ -53,9 +51,8 @@ def calc_model(model_spec, states, start, stop, T_dea=None, T_dea_times=None,
 
 def main():
     args = get_options("dea", model_path)
-    dea_check = ACISThermalCheck("1deamzt", "dea", MSID, 
-                                 VALIDATION_LIMITS, HIST_LIMIT, 
-                                 calc_model, args)
+    dea_check = ACISThermalCheck("1deamzt", "dea", VALIDATION_LIMITS, 
+                                 HIST_LIMIT, calc_model, args)
     try:
         dea_check.run()
     except Exception as msg:

--- a/dea_check/dea_check.py
+++ b/dea_check/dea_check.py
@@ -56,9 +56,8 @@ def main():
     dea_check = ACISThermalCheck("1deamzt", "dea", MSID, 
                                  VALIDATION_LIMITS, HIST_LIMIT, 
                                  calc_model, args)
-
     try:
-        dea_check.driver()
+        dea_check.run()
     except Exception as msg:
         if args.traceback:
             raise

--- a/dea_check/dea_model_spec.json
+++ b/dea_check/dea_model_spec.json
@@ -143,7 +143,7 @@
                     0.79
                 ], 
                 "eclipse_comp": "eclipse", 
-                "epoch": "2017:012", 
+                "epoch": "2017:211", 
                 "pitch_comp": "pitch", 
                 "simz_comp": "sim_z", 
                 "var_func": "linear"
@@ -207,22 +207,20 @@
             "name": "prop_heat__1deamzt"
         }
     ], 
-    "datestart": "2016:196:12:05:04.816", 
-    "datestop": "2017:194:23:50:40.816", 
+    "datestart": "2017:029:12:02:16.816", 
+    "datestop": "2018:029:11:49:28.816", 
     "dt": 328.0, 
     "gui_config": {
         "filename": "/home/jzuhone/dea_model_spec.json", 
         "plot_names": [
             "1deamzt data__time", 
             "1deamzt resid__time", 
-            "pitch data__time", 
-            "roll data__time", 
-            "ccd_count data__time"
+            "1deamzt resid__data"
         ], 
         "set_data_vals": {}, 
         "size": [
-            1758, 
-            1078
+            1827, 
+            1124
         ]
     }, 
     "mval_names": [], 
@@ -246,7 +244,7 @@
             "max": 2.0, 
             "min": -0.11139300563792043, 
             "name": "P_45", 
-            "val": 0.11202782769679334
+            "val": 0.11950129572145077
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
@@ -256,7 +254,7 @@
             "max": 2.0, 
             "min": -0.3441833953547427, 
             "name": "P_60", 
-            "val": 0.33222255438865161
+            "val": 0.34781581740414846
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
@@ -266,7 +264,7 @@
             "max": 2.0, 
             "min": -0.04055563694127384, 
             "name": "P_90", 
-            "val": 0.56611763869667353
+            "val": 0.52978475174985917
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
@@ -276,7 +274,7 @@
             "max": 2.0, 
             "min": 0.0, 
             "name": "P_110", 
-            "val": 1.2375443071679373
+            "val": 1.2350525841165401
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
@@ -286,7 +284,7 @@
             "max": 2.0, 
             "min": 0.0, 
             "name": "P_130", 
-            "val": 1.6370194485821261
+            "val": 1.696627548133558
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
@@ -296,7 +294,7 @@
             "max": 2.0, 
             "min": 0.0, 
             "name": "P_140", 
-            "val": 1.8333970218074545
+            "val": 1.8546229329934603
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
@@ -306,17 +304,17 @@
             "max": 2.0, 
             "min": 0.0, 
             "name": "P_150", 
-            "val": 1.8731309752348855
+            "val": 1.9470700383014485
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
             "fmt": "{:.4g}", 
             "frozen": true, 
             "full_name": "solarheat__1deamzt__P_160", 
-            "max": 2.0016461016569704, 
+            "max": 2.039721551185886, 
             "min": 0.0, 
             "name": "P_160", 
-            "val": 1.9783348178347131
+            "val": 1.96537412253601
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
@@ -326,7 +324,7 @@
             "max": 2.351249059942064, 
             "min": 0.0, 
             "name": "P_180", 
-            "val": 1.7411997991591071
+            "val": 1.9628067089898074
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
@@ -336,7 +334,7 @@
             "max": 1.0, 
             "min": -1.0, 
             "name": "dP_45", 
-            "val": 0.076123287818708502
+            "val": -0.11017121309785832
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
@@ -346,7 +344,7 @@
             "max": 1.0, 
             "min": -1.0, 
             "name": "dP_60", 
-            "val": 0.047293208498839751
+            "val": 0.063019659636453715
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
@@ -356,7 +354,7 @@
             "max": 1.0, 
             "min": -1.0, 
             "name": "dP_90", 
-            "val": 0.21027788751543297
+            "val": -0.34859075763380831
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
@@ -366,7 +364,7 @@
             "max": 1.0, 
             "min": -1.0, 
             "name": "dP_110", 
-            "val": 0.25922342440841528
+            "val": 0.34297599116523714
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
@@ -376,7 +374,7 @@
             "max": 1.0, 
             "min": -1.0, 
             "name": "dP_130", 
-            "val": 0.21458818920921999
+            "val": 0.10716675266864889
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
@@ -386,7 +384,7 @@
             "max": 1.0, 
             "min": -1.0, 
             "name": "dP_140", 
-            "val": 0.29905945194916528
+            "val": 0.10229742197636718
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
@@ -396,7 +394,7 @@
             "max": 1.0, 
             "min": -1.0, 
             "name": "dP_150", 
-            "val": 0.26164248837278825
+            "val": 0.24619298490615155
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
@@ -406,7 +404,7 @@
             "max": 1.0, 
             "min": -1.0, 
             "name": "dP_160", 
-            "val": 0.39365510535921505
+            "val": 0.29716232303036894
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
@@ -416,7 +414,7 @@
             "max": 1.0, 
             "min": -1.0, 
             "name": "dP_180", 
-            "val": 0.21476076627956175
+            "val": 0.50042225518252725
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
@@ -426,7 +424,7 @@
             "max": 3000.0, 
             "min": 1000.0, 
             "name": "tau", 
-            "val": 1279.3166049696767
+            "val": 1279.5046454248154
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
@@ -436,7 +434,7 @@
             "max": 1.0, 
             "min": -1.0, 
             "name": "ampl", 
-            "val": 0.048986180605473065
+            "val": 0.052467475913896382
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
@@ -453,10 +451,10 @@
             "fmt": "{:.4g}", 
             "frozen": true, 
             "full_name": "solarheat__1deamzt__hrc_bias", 
-            "max": 0.0, 
-            "min": 0.0, 
+            "max": 10.0, 
+            "min": -10.0, 
             "name": "hrc_bias", 
-            "val": 0.0
+            "val": -0.060292967101965599
         }, 
         {
             "comp_name": "solarheat_off_nom_roll__1deamzt", 
@@ -466,7 +464,7 @@
             "max": 5.0, 
             "min": -5.0, 
             "name": "P_plus_y", 
-            "val": -0.58249259903642492
+            "val": -0.55326235433760229
         }, 
         {
             "comp_name": "solarheat_off_nom_roll__1deamzt", 
@@ -476,27 +474,27 @@
             "max": 5.0, 
             "min": -5.0, 
             "name": "P_minus_y", 
-            "val": -0.44805298957630879
+            "val": -0.86135043361167751
         }, 
         {
             "comp_name": "heatsink__1deamzt", 
             "fmt": "{:.4g}", 
-            "frozen": true, 
+            "frozen": false, 
             "full_name": "heatsink__1deamzt__P", 
             "max": 10.0, 
             "min": -10.0, 
             "name": "P", 
-            "val": -1.9997966293848477
+            "val": -1.9976915946626255
         }, 
         {
             "comp_name": "heatsink__1deamzt", 
             "fmt": "{:.4g}", 
-            "frozen": true, 
+            "frozen": false, 
             "full_name": "heatsink__1deamzt__tau", 
             "max": 200.0, 
             "min": 2.0, 
             "name": "tau", 
-            "val": 28.086176857713099
+            "val": 27.73732703132421
         }, 
         {
             "comp_name": "heatsink__1deamzt", 
@@ -516,7 +514,7 @@
             "max": 60, 
             "min": 10, 
             "name": "pow_0xxx", 
-            "val": 11.577694907414893
+            "val": 10.380581350883318
         }, 
         {
             "comp_name": "dpa_power", 
@@ -526,7 +524,7 @@
             "max": 60, 
             "min": 15, 
             "name": "pow_1xxx", 
-            "val": 24.804809013804832
+            "val": 19.852640719795332
         }, 
         {
             "comp_name": "dpa_power", 
@@ -536,17 +534,17 @@
             "max": 80, 
             "min": 20, 
             "name": "pow_2xxx", 
-            "val": 27.806175226323077
+            "val": 27.639545434446816
         }, 
         {
             "comp_name": "dpa_power", 
             "fmt": "{:.4g}", 
-            "frozen": true, 
+            "frozen": false, 
             "full_name": "dpa_power__pow_3xx0", 
             "max": 100, 
             "min": 20, 
             "name": "pow_3xx0", 
-            "val": 38.898426416112429
+            "val": 31.408230032317274
         }, 
         {
             "comp_name": "dpa_power", 
@@ -556,7 +554,7 @@
             "max": 100, 
             "min": 20, 
             "name": "pow_3xx1", 
-            "val": 38.898426416112429
+            "val": 36.995841085839913
         }, 
         {
             "comp_name": "dpa_power", 
@@ -566,17 +564,17 @@
             "max": 120, 
             "min": 20, 
             "name": "pow_4xxx", 
-            "val": 46.587094239038109
+            "val": 44.922995037294932
         }, 
         {
             "comp_name": "dpa_power", 
             "fmt": "{:.4g}", 
-            "frozen": false, 
+            "frozen": true, 
             "full_name": "dpa_power__pow_55x0", 
             "max": 120, 
             "min": 20, 
             "name": "pow_55x0", 
-            "val": 28.399999999999949
+            "val": 28.688493925945245
         }, 
         {
             "comp_name": "dpa_power", 
@@ -586,7 +584,7 @@
             "max": 120, 
             "min": 20, 
             "name": "pow_5xxx", 
-            "val": 53.813142539800936
+            "val": 53.862615033403202
         }, 
         {
             "comp_name": "dpa_power", 
@@ -596,7 +594,7 @@
             "max": 140, 
             "min": 20, 
             "name": "pow_66x0", 
-            "val": 28.085371130427838
+            "val": 31.408230032317274
         }, 
         {
             "comp_name": "dpa_power", 
@@ -606,7 +604,7 @@
             "max": 140, 
             "min": 20, 
             "name": "pow_6611", 
-            "val": 62.529035361140785
+            "val": 62.177343680863189
         }, 
         {
             "comp_name": "dpa_power", 
@@ -616,7 +614,7 @@
             "max": 140, 
             "min": 20, 
             "name": "pow_6xxx", 
-            "val": 53.494776735848305
+            "val": 56.540825216349631
         }, 
         {
             "comp_name": "dpa_power", 
@@ -626,7 +624,7 @@
             "max": 2.0, 
             "min": 0.0, 
             "name": "mult", 
-            "val": 1.6846327116941155
+            "val": 1.6728015712752409
         }, 
         {
             "comp_name": "dpa_power", 
@@ -646,7 +644,7 @@
             "max": 2.0, 
             "min": 0.0, 
             "name": "k", 
-            "val": 0.183785101347619
+            "val": 0.17909760134761898
         }, 
         {
             "comp_name": "prop_heat__1deamzt", 

--- a/dea_check/tests/conftest.py
+++ b/dea_check/tests/conftest.py
@@ -1,9 +1,2 @@
-import pytest
-
-def pytest_addoption(parser):
-    parser.addoption("--answer_store", 
-        help="Generate new answers, but don't test. Argument is the directory to store the answers to.")
-
-@pytest.fixture()
-def answer_store(request):
-    return request.config.getoption('--answer_store')
+from acis_thermal_check.regression_testing import \
+    pytest_addoption, answer_store

--- a/dea_check/tests/conftest.py
+++ b/dea_check/tests/conftest.py
@@ -5,5 +5,5 @@ def pytest_addoption(parser):
         help="Generate new answers, but don't test. Argument is the directory to store the answers to.")
 
 @pytest.fixture()
-def generate_answers(request):
+def answer_store(request):
     return request.config.getoption('--answer_store')

--- a/dea_check/tests/test_dea.py
+++ b/dea_check/tests/test_dea.py
@@ -1,9 +1,11 @@
 from ..dea_check import VALIDATION_LIMITS, \
     HIST_LIMIT, calc_model, model_path
 from acis_thermal_check.regression_testing import \
-    run_test_arrays
+    RegressionTester
+
+dea_rt = RegressionTester("1deamzt", "dea", model_path, VALIDATION_LIMITS,
+                          HIST_LIMIT, calc_model)
 
 def test_dea_loads(answer_store):
-    run_test_arrays("1deamzt", "dea", model_path,
-                    [VALIDATION_LIMITS, HIST_LIMIT, calc_model],
-                    answer_store)
+    dea_rt.run_test_arrays([VALIDATION_LIMITS, HIST_LIMIT, calc_model],
+                           answer_store)

--- a/dea_check/tests/test_dea.py
+++ b/dea_check/tests/test_dea.py
@@ -1,12 +1,11 @@
 from ..dea_check import dea_check, model_path
 from acis_thermal_check.regression_testing import \
-    load_test_template
+    load_test_template, test_loads
 import os
 
 default_model_spec = os.path.join(model_path, "dea_model_spec.json")
 
-def test_dea_may3016(answer_store):
-    run_start = "2016:122:12:00:00.000"
-    load_week = "MAY3016"
-    load_test_template("1deamzt", "dea", answer_store, run_start, 
-                       load_week, default_model_spec, dea_check)
+def test_dea_loads(answer_store):
+    for load_week in test_loads:
+        load_test_template("dea", dea_check, default_model_spec,
+                           load_week, answer_store)

--- a/dea_check/tests/test_dea.py
+++ b/dea_check/tests/test_dea.py
@@ -1,4 +1,5 @@
-from ..dea_check import dea_check, model_path
+from ..dea_check import MSID, VALIDATION_LIMITS, \
+    HIST_LIMIT, calc_model, model_path
 from acis_thermal_check.regression_testing import \
     load_test_template, test_loads
 import os
@@ -7,5 +8,6 @@ default_model_spec = os.path.join(model_path, "dea_model_spec.json")
 
 def test_dea_loads(answer_store):
     for load_week in test_loads:
-        load_test_template("dea", dea_check, default_model_spec,
-                           load_week, answer_store)
+        load_test_template("dea", "1deamzt", load_week,
+                           [MSID, VALIDATION_LIMITS, HIST_LIMIT, calc_model],
+                           answer_store)

--- a/dea_check/tests/test_dea.py
+++ b/dea_check/tests/test_dea.py
@@ -6,5 +6,4 @@ from acis_thermal_check.regression_testing import \
 def test_dea_loads(answer_store):
     run_test_arrays("1deamzt", "dea", model_path,
                     [VALIDATION_LIMITS, HIST_LIMIT, calc_model],
-                    answer_store, 
-                    exclude_images=["1deamzt_valid.png","1deamzt.png","pow_sim.png"])
+                    answer_store)

--- a/dea_check/tests/test_dea.py
+++ b/dea_check/tests/test_dea.py
@@ -1,13 +1,23 @@
-from ..dea_check import MSID, VALIDATION_LIMITS, \
+from ..dea_check import VALIDATION_LIMITS, \
     HIST_LIMIT, calc_model, model_path
 from acis_thermal_check.regression_testing import \
-    load_test_template, test_loads
+    load_test_template, normal_loads, too_loads, \
+    stop_loads
 import os
 
 default_model_spec = os.path.join(model_path, "dea_model_spec.json")
 
 def test_dea_loads(answer_store):
-    for load_week in test_loads:
-        load_test_template("dea", "1deamzt", load_week,
-                           [MSID, VALIDATION_LIMITS, HIST_LIMIT, calc_model],
-                           answer_store)
+    for load_week in normal_loads:
+        load_test_template("1deamzt", "dea", default_model_spec, load_week,
+                           [VALIDATION_LIMITS, HIST_LIMIT, calc_model],
+                           answer_store, exclude_images=["1deamzt_valid.png","1deamzt.png","pow_sim.png"])
+    for load_week in too_loads:
+        load_test_template("1deamzt", "dea", default_model_spec, load_week,
+                           [VALIDATION_LIMITS, HIST_LIMIT, calc_model],
+                           answer_store, interrupt=True, exclude_images=["1deamzt_valid.png","1deamzt.png","pow_sim.png"])
+    for load_week in stop_loads:
+        load_test_template("1deamzt", "dea", default_model_spec, load_week,
+                           [VALIDATION_LIMITS, HIST_LIMIT, calc_model],
+                           answer_store, interrupt=True, exclude_images=["1deamzt_valid.png","1deamzt.png","pow_sim.png"])
+

--- a/dea_check/tests/test_dea.py
+++ b/dea_check/tests/test_dea.py
@@ -7,5 +7,4 @@ dea_rt = RegressionTester("1deamzt", "dea", model_path, VALIDATION_LIMITS,
                           HIST_LIMIT, calc_model)
 
 def test_dea_loads(answer_store):
-    dea_rt.run_test_arrays([VALIDATION_LIMITS, HIST_LIMIT, calc_model],
-                           answer_store)
+    dea_rt.run_test_arrays(answer_store)

--- a/dea_check/tests/test_dea.py
+++ b/dea_check/tests/test_dea.py
@@ -1,23 +1,10 @@
 from ..dea_check import VALIDATION_LIMITS, \
     HIST_LIMIT, calc_model, model_path
 from acis_thermal_check.regression_testing import \
-    load_test_template, normal_loads, too_loads, \
-    stop_loads
-import os
-
-default_model_spec = os.path.join(model_path, "dea_model_spec.json")
+    run_test_arrays
 
 def test_dea_loads(answer_store):
-    for load_week in normal_loads:
-        load_test_template("1deamzt", "dea", default_model_spec, load_week,
-                           [VALIDATION_LIMITS, HIST_LIMIT, calc_model],
-                           answer_store, exclude_images=["1deamzt_valid.png","1deamzt.png","pow_sim.png"])
-    for load_week in too_loads:
-        load_test_template("1deamzt", "dea", default_model_spec, load_week,
-                           [VALIDATION_LIMITS, HIST_LIMIT, calc_model],
-                           answer_store, interrupt=True, exclude_images=["1deamzt_valid.png","1deamzt.png","pow_sim.png"])
-    for load_week in stop_loads:
-        load_test_template("1deamzt", "dea", default_model_spec, load_week,
-                           [VALIDATION_LIMITS, HIST_LIMIT, calc_model],
-                           answer_store, interrupt=True, exclude_images=["1deamzt_valid.png","1deamzt.png","pow_sim.png"])
-
+    run_test_arrays("1deamzt", "dea", model_path,
+                    [VALIDATION_LIMITS, HIST_LIMIT, calc_model],
+                    answer_store, 
+                    exclude_images=["1deamzt_valid.png","1deamzt.png","pow_sim.png"])


### PR DESCRIPTION
This PR provides the updates to `dea_check` to make it work with the new version of `acis_thermal_check` (PR acisops/acis_thermal_check#14). The result is a simplified code base and improved support for regression testing.

Highlights:

1. The yellow and margin limits are obtained using the `get_acis_limits` function internally in `ACISThermalCheck` and no longer need to be kept in this script.
2. It is no longer necessary for the script to construct the `StateBuilder` object as this now happens internally in `ACISThermalCheck`.
3. An updated regression test has been added which tests model outputs against validated answers for a number of loads.