### PR TITLE
Don't use version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,10 +12,5 @@ setup(name='dea_check',
       author_email='jzuhone@gmail.com',
       url='http://github.com/acisops/dea_check',
       include_package_data=True,
-      classifiers=[
-          'Intended Audience :: Science/Research',
-          'Operating System :: OS Independent',
-          'Programming Language :: Python :: 3',
-      ],
       entry_points=entry_points,
       )

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 from setuptools import setup
-from dea_check import __version__
 
 entry_points = {'console_scripts': 'dea_check = dea_check.dea_check:main'}
-
-url = 'https://github.com/acisops/dea_check/tarball/{}'.format(__version__)
 
 setup(name='dea_check',
       packages=["dea_check"],
@@ -14,13 +11,11 @@ setup(name='dea_check',
       author='John ZuHone',
       author_email='jzuhone@gmail.com',
       url='http://github.com/acisops/dea_check',
-      download_url=url,
       include_package_data=True,
       classifiers=[
           'Intended Audience :: Science/Research',
           'Operating System :: OS Independent',
-          'Programming Language :: Python :: 2.7',
-          'Programming Language :: Python :: 3.5',
+          'Programming Language :: Python :: 3',
       ],
       entry_points=entry_points,
       )


### PR DESCRIPTION
This PR removes the import of `__version__` in `setup.py`, and also cleans up other unneeded things in that file.