### PR TITLE
Update regression testing

### DIFF
--- a/dea_check/tests/answers/DEC0919A_viol.json
+++ b/dea_check/tests/answers/DEC0919A_viol.json
@@ -18,5 +18,10 @@
     "limits": {
         "yellow_hi_limit": 37.2,
         "plan_hi_limit": 35.2
-    }
+    },
+    "duration": [
+        "0.46",
+        "0.33",
+        "1.64"
+    ]
 }

--- a/dea_check/tests/answers/DEC0919A_viol.json
+++ b/dea_check/tests/answers/DEC0919A_viol.json
@@ -16,7 +16,7 @@
     ],
     "run_start": "2019:338:14:25:26.816",
     "limits": {
-        "yellow_hi": 37.2,
-        "plan_limit_hi": 35.2
+        "yellow_hi_limit": 37.2,
+        "plan_hi_limit": 35.2
     }
 }

--- a/dea_check/tests/dea_test_spec.json
+++ b/dea_check/tests/dea_test_spec.json
@@ -170,7 +170,7 @@
                     0.79
                 ],
                 "eclipse_comp": "eclipse",
-                "epoch": "2016:188",
+                "epoch": "2016:188:12:00:00",
                 "pitch_comp": "pitch",
                 "simz_comp": "sim_z",
                 "var_func": "linear"


### PR DESCRIPTION
## Description

Minor updates to the regression tests are required, to account for changes in https://github.com/acisops/acis_thermal_check/pull/37:

* The additions of violation durations to the violation test answers
* The changing of the limit variable names
* Adding explicit `12:00:00` to the epoch value in the test model specification to accommodate the switch to `cxotime`

## Testing

- [x] Passes unit tests on MacOS, linux, Windows (at least one required)
- [x] Functional testing